### PR TITLE
Update dependencies

### DIFF
--- a/ts/build/packages/xfwm4/dependencies
+++ b/ts/build/packages/xfwm4/dependencies
@@ -7,4 +7,4 @@ xorg7
 at-spi2
 gnome-core
 gtk-3.0
-xfce-polkit networkmanager
+xfce-polkit


### PR DESCRIPTION
xfce-polkit and networkmanager were on the same line which caused both dependencies not to install

"NetworkManager" has been removed as it doesn't need to be there...