### PR TITLE
Always install xfce-polkit when installing xfwm4

### DIFF
--- a/ts/build/packages/xfwm4/dependencies
+++ b/ts/build/packages/xfwm4/dependencies
@@ -7,4 +7,5 @@ xorg7
 at-spi2
 gnome-core
 gtk-3.0
-xfce-polkit networkmanager
+xfce-polkit
+networkmanager

--- a/ts/build/packages/xfwm4/dependencies
+++ b/ts/build/packages/xfwm4/dependencies
@@ -8,4 +8,3 @@ at-spi2
 gnome-core
 gtk-3.0
 xfce-polkit
-networkmanager


### PR DESCRIPTION
This fixes an issue where xfce-polkit was not installed, and failing out of e.g. freerdp session would not shut down the system.