### PR TITLE
Fixed ica_receiver_clear_credentials.sh and add ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_STORE_CLOSED

### DIFF
--- a/ts/build/conf/ica_receiver.conf.sample
+++ b/ts/build/conf/ica_receiver.conf.sample
@@ -32,14 +32,17 @@
 #                                                              Otherwise: if the user logs on to the Receiver and launches a session, and leaves or disconnects
 #                                                              the session, his/hers credentials are still logged on to the Receiver and anyone could simple start (logon)
 #
-#ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS             Same as ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED, but instead of
+#ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_STORE_CLOSED              true or false, similar to ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED 
+#                                                              If true, the users credentials are cleard afther he/she closes the ICASTORE.
+#
+#ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS             Numeric value, similar to ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED, but instead of
 #                                                              clearing the session directly after the first session starts, the credentials are cleard
-#                                                              X minutes (ICA_RECEIVER_CLEAR_CREDENTIALS_CHECK_INTERVAL) after the last session has ended.
+#                                                              X minutes (ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS) after the last session has ended.
 #                                                              This makes it easier for the user since he/she can then close sessions and easily start them
 #                                                              again directly (within the time timeout limit) without having to logon.
 #
-#ICA_RECEIVER_CLEAR_CREDENTIALS_CHECK_INTERVAL                  Numeric value, default if not defined is 5. The check interval (timeout) used
-#                                                              by ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED and ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS
+#ICA_RECEIVER_CLEAR_CREDENTIALS_CHECK_INTERVAL                 Numeric value, check interval (timeout) used by ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_STORE_CLOSED, ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED
+#                                                              and ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS
 #
 #
 #Examples of configuration for Citrix Receiver:

--- a/ts/build/packages/ica/build/conf/50ica_receiver
+++ b/ts/build/packages/ica/build/conf/50ica_receiver
@@ -32,14 +32,17 @@
 #                                                              Otherwise: if the user logs on to the Receiver and launches a session, and leaves or disconnects
 #                                                              the session, his/hers credentials are still logged on to the Receiver and anyone could simple start (logon)
 #
-#ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS             Same as ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED, but instead of
+#ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_STORE_CLOSED              true or false, similar to ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED 
+#                                                              If true, the users credentials are cleard afther he/she closes the ICASTORE.
+#
+#ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS             Numeric value, similar to ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED, but instead of
 #                                                              clearing the session directly after the first session starts, the credentials are cleard
-#                                                              X minutes (ICA_RECEIVER_CLEAR_CREDENTIALS_CHECK_INTERVAL) after the last session has ended.
+#                                                              X minutes (ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS) after the last session has ended.
 #                                                              This makes it easier for the user since he/she can then close sessions and easily start them
 #                                                              again directly (within the time timeout limit) without having to logon.
 #
-#ICA_RECEIVER_CLEAR_CREDENTIALS_CHECK_INTERVAL                  Numeric value, default if not defined is 5. The check interval (timeout) used
-#                                                              by ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED and ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS
+#ICA_RECEIVER_CLEAR_CREDENTIALS_CHECK_INTERVAL                 Numeric value, check interval (timeout) used by ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_STORE_CLOSED, ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED
+#                                                              and ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS
 #
 #
 #Examples of configuration for Citrix Receiver:

--- a/ts/build/packages/ica/build/extra/bin/ica_receiver_clear_credentials.sh
+++ b/ts/build/packages/ica/build/extra/bin/ica_receiver_clear_credentials.sh
@@ -1,24 +1,46 @@
 #! /bin/sh
 
-. $TS_GLOBAL
+. /etc/thinstation.global
+
+export DISPLAY=:0.0
+export XAUTHORITY=/run/lightdm/$USER/xauthority
 
 ICA_ROOT=/opt/Citrix/ICAClient
 ICA_STOREBROWSE=$ICA_ROOT/util/storebrowse
-ICA_SELFSERVICE=$ICA_ROOT/selfservice
-LOGGERTAG="ica_receiver_config.sh"
-ALIVEFILE=/tmp/ica_receiver_clear_credentials_alive
-DEADFILE=/tmp/ica_receiver_clear_credentials_dead
+LOGGERTAG="ica_receiver_clear_credentials.sh"
+SESSION_ALIVEFILE=/tmp/ica_receiver_clear_credentials_session_alive
+SESSION_DEADFILE=/tmp/ica_receiver_clear_credentials_session_dead
+
+ICASTORE_ALIVEFILE=/tmp/ica_receiver_clear_credentials_store_alive
+
+# Check if any Citrix icastore are running
+if is_enabled ${ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_STORE_CLOSED} ; then
+	if ps -o comm | egrep -q "icastore"; then
+		# icastore is running
+		if [ ! -f $ICASTORE_ALIVEFILE ]; then
+			touch $ICASTORE_ALIVEFILE
+		fi
+
+	elif [ -f $ICASTORE_ALIVEFILE ] ; then
+		# This section will only be run the first time we notice that all icastore have been closed.
+
+		rm -f $ICASTORE_ALIVEFILE
+
+		logger --stderr --tag $LOGGERTAG "Clearing the user credentials for Citrix Receiver since since all previously running Citrix icastore now has ended and ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_STORE_CLOSED is enabled."
+		$ICA_STOREBROWSE --killdaemon
+	fi
+fi
 
 # Check if any Citrix sessions are running
 if ps -o comm | egrep -q "wfica"; then
 	# A Citrix session are running
-	rm -f $DEADFILE
+	rm -f $SESSION_DEADFILE
 
 	# Check if it's a newly started Citrix session
-	if [ ! -f $ALIVEFILE ]; then
+	if [ ! -f $SESSION_ALIVEFILE ]; then
 	
 		# Create the alive file
-		touch $ALIVEFILE
+		touch $SESSION_ALIVEFILE
 	
 		# Check if we shall clear the credentials as soon as the user has launched a Citrix session
 		if is_enabled ${ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED} ; then
@@ -28,13 +50,11 @@ if ps -o comm | egrep -q "wfica"; then
 			logger --stderr --tag $LOGGERTAG "Detected that a Citrix session have been launched but ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED is not enabled."
 		fi
 	fi
-
-
-elif [ -f $ALIVEFILE ] && [ ! -f $DEADFILE ]; then
+elif [ -f $SESSION_ALIVEFILE ] && [ ! -f $SESSION_DEADFILE ]; then
 	# This section will only be run the first time we notice that all Citrix sessions have been closed.
 	
 	# No Citrix session is running, kill the alive file
-	rm -f $ALIVEFILE
+	rm -f $SESSION_ALIVEFILE
 
 
 	# Check if we EVER shall clear the credentials after all the Citrix sessions has ended
@@ -46,16 +66,16 @@ elif [ -f $ALIVEFILE ] && [ ! -f $DEADFILE ]; then
 			$ICA_STOREBROWSE --killdaemon
 		else
 			# Create a timestamp if this is the first time we run this since the sessions ended
-			date +%s > $DEADFILE
+			date +%s > $SESSION_DEADFILE
 		fi
 	fi
 
 
-elif [ -f $DEADFILE ] && [ -n "${ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS}" ]; then
+elif [ -f $SESSION_DEADFILE ] && [ -n "${ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS}" ]; then
 	# We have a deadfile (=waiting for 
 
 	# Get the last timestamp when the processes was running
-	DEADTIMESTAMP=$(cat $DEADFILE)
+	DEADTIMESTAMP=$(cat $SESSION_DEADFILE)
 
 	# Calculate the time difference
 	TIME=$(date +%s)
@@ -66,7 +86,7 @@ elif [ -f $DEADFILE ] && [ -n "${ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_EN
 		$ICA_STOREBROWSE --killdaemon
 		
 		# Delete the deadfile (otherwise this will run everytime)
-		rm -f $DEADFILE
+		rm -f $SESSION_DEADFILE
 	else
 		logger --stderr --tag $LOGGERTAG "Waiting for delay time ${ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS} minutes before clearing user credentials in Citrix Receiver. No Citrix sessions have been running for the last $(($IDLE / 60)) minutes."
 	fi

--- a/ts/build/packages/ica/build/extra/bin/ica_receiver_config.sh
+++ b/ts/build/packages/ica/build/extra/bin/ica_receiver_config.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-. $TS_GLOBAL
+. /etc/thinstation.global
 
 LOGGERTAG="ica_receiver_config.sh"
 
@@ -9,14 +9,7 @@ LOGGERTAG="ica_receiver_config.sh"
 ##
 
 # See if we shall schedule a job to clear the users credentials in Citrix Receiver
-if is_enabled ${ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED} || [ -n "${ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS}" ]; then
-	# Set the default check interval to 5 minutes
-	CHECK_INTERVAL=5
-
-	# Use the specified time if we have that defined. (cast it into an integer)
-	if [ -n "${ICA_RECEIVER_CLEAR_CREDENTIALS_CHECK_INTERVAL}" ]; then
-		CHECK_INTERVAL=$ICA_RECEIVER_CLEAR_CREDENTIALS_CHECK_INTERVAL
-	fi
+if is_enabled ${ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_STORE_CLOSED} || is_enabled ${ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED} || [ -n "${ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS}" ]; then
 		
 	# See if we shall schedule a job to clear the users credentials in Citrix Receiver
 	# (cast it to an integer so if it's not defined it will return 0)
@@ -27,10 +20,10 @@ if is_enabled ${ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED} || [ -n "$
 			(crontab -l || true; echo "*/$((ICA_RECEIVER_CLEAR_CREDENTIALS_CHECK_INTERVAL)) * * * * /bin/ica_receiver_clear_credentials.sh")| crontab -
 		fi
 	else
-		logger --stderr --tag $LOGGERTAG "ICA_RECEIVER_CLEAR_CREDENTIALS_CHECK_INTERVAL is 0 although ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED and/or ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS are defined. No job and will not be added to crontab!"
+		logger --stderr --tag $LOGGERTAG "ICA_RECEIVER_CLEAR_CREDENTIALS_CHECK_INTERVAL is 0 although ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_STORE_CLOSED and/or ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED and/or ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS are defined. No job and will not be added to crontab!"
 	fi
 else
-	logger --stderr --tag $LOGGERTAG "Neither ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED or ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS are set, no job will be added to crontab."
+	logger --stderr --tag $LOGGERTAG "Neither ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_STORE_CLOSED or ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_SESSION_LAUNCHED or ICA_RECEIVER_CLEAR_CREDENTIALS_AFTER_SESSION_ENDS are set, no job will be added to crontab."
 fi
 
 ####


### PR DESCRIPTION
Fixed ica_receiver_clear_credentials.sh

Add parameter ICA_RECEIVER_CLEAR_CREDENTIALS_WHEN_STORE_CLOSED that remove credentials when citrix icastore is closed.