### PR TITLE
Fixes for NoMachine client

### DIFF
--- a/ts/build/packages/nx/build/extra/etc/init.d/nx-init
+++ b/ts/build/packages/nx/build/extra/etc/init.d/nx-init
@@ -54,6 +54,10 @@ init)
 	fi
 
 	let x=0
+
+	NXHOSTSCRT=$HOME/.nx/config/hosts.crt
+	rm $NXHOSTSCRT
+
 	while [ -n "`eval echo '$SESSION_'$x'_TYPE'`" ] ; do
 	  NXTYPE=`eval echo '$SESSION_'$x'_TYPE'`
 	  if [ "`make_caps $NXTYPE`" = "NX" ] ; then
@@ -65,7 +69,7 @@ init)
 
 	    (set | grep "SESSION_"$x"_NX_" ) |
 	    while read session; do
-              # Reworked below line to allow multiline NX options, ie ssh keys
+		  # Reworked below line to allow multiline NX options, ie ssh keys
 	      nxvalue=`echo $session | cut -f1 -d"="`
 	      eval nxvalue=\$$nxvalue
 	      line=`echo $session | cut -f1 -d"="`
@@ -73,10 +77,14 @@ init)
 
 	      # Work around for groups which are > than 1 word long
 	      case $nxgroup in
-		      VNC|WINDOWS|SHARE)
+			VNC|WINDOWS|SHARE)
 	      		nxgroup=`echo $line | cut -f4-5 -d"_"`
-			linestart=6
-		      ;;
+				linestart=6
+		      	;;
+			HOSTSCRT)
+			  	echo -e "$nxvalue" >> $NXHOSTSCRT
+			  	continue
+				;;
 		      *)
 			linestart=5
 		      ;;

--- a/ts/build/packages/nx/build/extra/etc/nx.tpl
+++ b/ts/build/packages/nx/build/extra/etc/nx.tpl
@@ -1,2 +1,2 @@
 <!DOCTYPE NXClientSettings>
-<NXClientSettings application="nxclient" version="1.3" >
+<NXClientSettings version="2.2" application="nxclient" >

--- a/ts/build/packages/nx/build/extra/etc/systemd/system/nx-init.service
+++ b/ts/build/packages/nx/build/extra/etc/systemd/system/nx-init.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=ThinStation nx-init
-After=profile-setup.service pkg.service tsinit.target
+After=profile-setup.service net.profile-setup.service pkg.service tsinit.target
+Before=session-setup.service
 ConditionPathIsReadWrite=/etc
 
 [Service]

--- a/ts/build/packages/nx/build/finalize
+++ b/ts/build/packages/nx/build/finalize
@@ -1,4 +1,1 @@
-#nomachine 10
-. /build/scripts/nomachine_8.14.2_1_x86_64.rpm_preinstall.sh
-. /build/scripts/nomachine_8.14.2_1_x86_64.rpm_postinstall.sh
 systemctl enable nx-init

--- a/ts/build/packages/nx/build/install
+++ b/ts/build/packages/nx/build/install
@@ -2,3 +2,5 @@
 export PACKAGE=nx
 export RPM=`basename $1`
 repackage -e
+
+cp -av /usr/NX $TSWRKNG/packages/nx/lib64/NX/


### PR DESCRIPTION
Fixes for NoMachine client integration:

Simplified unpacking of RPM - just copies the installed /usr/NX/ to the image path
Changed the nx-init systemd ordering, so the netfiles get loaded before generating the nx config files
Added support for hosts.crt file, which is used in later versions of nx (use SESSION_X_NX_HOSTSCRT variable)
Upgraded XML template version from 1.3 to 2.2 so more things can be added to the nxs files

This is testes against the latest enterprise version, but should be the same with recent non-enterprise versions