### PR TITLE
Add autostart mode selection

### DIFF
--- a/ts/build/conf/master.conf.sample
+++ b/ts/build/conf/master.conf.sample
@@ -138,8 +138,11 @@ ALLOW_EXIT=Off
 #                           - xterm            Start xterm client
 #                           - tn5250           Start AS400 client in linux console
 #                           - nx               Start NX Client Session
-# SESSION_#_AUTOSTART       ON      Application will be executed immediately at startup
-#                           OFF     Application will appear in a menu to be started manually
+# SESSION_#_AUTOSTART       ON      	Application will be executed immediately at startup
+#                           WINDOW     	Application will be executed immediately at startup in window mode
+#                           FULLSCREEN	Application will be executed immediately at startup in fullscreen mode
+#                           CONSOLE     Application will be executed immediately at startup in console mode
+#                           OFF     	Application will appear in a menu to be started manually
 # SESSION_#_CUSTOM_CONFIG   ON      Allows choosing custom config for when session starts
 #                           OFF     Session boots normally
 # SESSION_#_ICON            ON      Places Icon on Desktop if package xtdesk is selected and

--- a/ts/build/packages/base/etc/thinstation.packages
+++ b/ts/build/packages/base/etc/thinstation.packages
@@ -128,25 +128,29 @@ run_command()
 
 mode=$1
 case "$mode" in
-auto)
-  while [ "$reconnect" != "1" ]	; do
-    echo "Running Auto $PACKAGE" >> $APPLOG
-    package_input
-    if [ -z "$MODE" ]	; then
-        MODE=CONSOLE
-    fi
-    order_command
-    wm_workspaces "$CMD" "$4"
-    xterm_wrapper
-    if find_network	; then
-	    run_command
-    fi
-    pkg_check_status
-    wait
-        check_NX
-        check_reboot
-    check_reconnect
-  done
+auto|auto_window|auto_fullscreen)
+	while [ "$reconnect" != "1" ]	; do
+		echo "Running Auto $PACKAGE" >> $APPLOG
+		MODE=GLOBAL
+		if [ "$mode" == "auto_window" ]	; then
+			MODE="WINDOW"
+		fi
+		if [ "$mode" == "auto_fullscreen" ]	; then
+			MODE="FULLSCREEN"
+		fi
+		package_input
+		order_command
+		wm_workspaces "$CMD" "$4"
+		xterm_wrapper
+		if find_network	; then
+			run_command
+		fi
+		pkg_check_status
+		wait
+		check_NX
+		check_reboot
+		check_reconnect
+	done
     $NO_SESSION
     ;;
 console)
@@ -162,21 +166,21 @@ console)
     use_xrandr
     use_xinput
     use_wallpaper
-    while [ -e /tmp/.X11-unix/X$DISPLAY_NUMBER ] && [ "$reconnect" != "1" ]	; do
-	package_input
-	MODE=CONSOLE
-	order_command
-	xterm_wrapper
-	eula_
-	if find_network	; then
-	        run_command
-	fi
-	pkg_check_status
-	wait
-	check_NX
-	check_xrunning
-	check_reboot
-	check_reconnect
+		while [ -e /tmp/.X11-unix/X$DISPLAY_NUMBER ] && [ "$reconnect" != "1" ]	; do
+		MODE=CONSOLE
+		package_input
+		order_command
+		xterm_wrapper
+		eula_
+		if find_network	; then
+			run_command
+		fi
+		pkg_check_status
+		wait
+		check_NX
+		check_xrunning
+		check_reboot
+		check_reconnect
     done
     $NO_SESSION
     ;;
@@ -189,10 +193,8 @@ window|fullscreen)
     if ! is_disabled $ALLOW_SERVER_EDITS	; then
 	ALLOW_SERVER_EDITS=TRUE
     fi
+	MODE=`make_caps "$mode"`
     package_input
-    if [ -z "$MODE" ]	; then
-	    MODE=`make_caps "$mode"`
-    fi
     order_command
     xterm_wrapper
     if find_network	; then
@@ -201,7 +203,7 @@ window|fullscreen)
     pkg_check_status
     ;;
 help)
-    echo "Usage: $0 {console|menu|window|fullscreen} [server] [options]"
+    echo "Usage: $0 {auto|auto_window|auto_fullscreen|console|menu|window|fullscreen} [server] [options] [workspace] [user] [pass_enable] [gate] [gate_user]"
     ;;
   *)
     exit 1

--- a/ts/build/packages/xfwm4/build/extra/etc/xfwm4.functions
+++ b/ts/build/packages/xfwm4/build/extra/etc/xfwm4.functions
@@ -382,9 +382,25 @@ wm_menu()
 					fi
 				;;
 			esac
+			autostart=`make_caps $autostart`
 			case "$autostart" in
-				ON)
+				TRUE|ON|ENABLED|ENABLE|YES|POSITIVE|Y|AUTO)
 					command="pkg auto $type \"$server\" \"$options\" \"$workspace\" \"$user\" \"$pass_enable\" \"$gate\" \"$gate_user\""
+					ICONDIR=$HOME/.config/autostart
+					make_desktop
+				;;
+				WINDOW|WINDOWS)
+					command="pkg auto_window $type \"$server\" \"$options\" \"$workspace\" \"$user\" \"$pass_enable\" \"$gate\" \"$gate_user\""
+					ICONDIR=$HOME/.config/autostart
+					make_desktop
+				;;
+				FULLSCREEN|FULL)
+					command="pkg auto_fullscreen $type \"$server\" \"$options\" \"$workspace\" \"$user\" \"$pass_enable\" \"$gate\" \"$gate_user\""
+					ICONDIR=$HOME/.config/autostart
+					make_desktop
+				;;
+				CONSOLE)
+					command="pkg console $type \"$server\" \"$options\" \"$workspace\" \"$user\" \"$pass_enable\" \"$gate\" \"$gate_user\""
 					ICONDIR=$HOME/.config/autostart
 					make_desktop
 				;;


### PR DESCRIPTION
Now the session_x_autostart property can be: on, window, fullscreen or console.

The app will be started automatically (with reconnection) in the desired mode.