### PR TITLE
Fix an issue with hdupdate

### DIFF
--- a/ts/build/packages/hdupdate/build/finalize
+++ b/ts/build/packages/hdupdate/build/finalize
@@ -1,3 +1,4 @@
 #hdupdate 20
 
 chmod +x /etc/init.d/hdupdate
+systemctl enable hdupdate

--- a/ts/build/packages/hdupdate/etc/systemd/system/tsinit.target.wants/hdupdate.service
+++ b/ts/build/packages/hdupdate/etc/systemd/system/tsinit.target.wants/hdupdate.service
@@ -1,1 +1,0 @@
-../hdupdate.service


### PR DESCRIPTION
Fix "tsinit.target: Wants dependency dropin /etc/systemd/system/tsinit.target.wants/hdupdate.service is not a symlink, ignoring."
