### PR TITLE
Compatibility with `ls` from coreutils

### DIFF
--- a/ts/build/packages/base/etc/thinstation.functions
+++ b/ts/build/packages/base/etc/thinstation.functions
@@ -633,7 +633,7 @@ get_res ()
 check_last_session ()
 {
 	if [ $(ls -l $APPLOGDIR |grep -e xorg -c) -gt 0 ]; then
-		lastlog=$(ls -ltr $APPLOGDIR |grep -e xorg |tail -n1 |cut -c 58-)
+		lastlog=$(ls -1tr $APPLOGDIR |grep -e xorg |tail -n1)
 		if [ $(tail -n1 $APPLOGDIR/$lastlog |grep -cF '(0)') -gt 0 ]; then
 			return 0
 		else


### PR DESCRIPTION
Column spacing of `ls` is different between busybox and coreutils.
As the column spacing is reduced in the coreutils version, the `cut` overshoots the file name, so `$lastlog` is empty and the function returns `1` instead of `0`.

Both the `ls` from busybox and coreutils support the `-1` parameter for a single file per line, so `cut` is no longer required.

