### PR TITLE
Fix auto-download using `setup-chroot -a`

### DIFF
--- a/setup-chroot
+++ b/setup-chroot
@@ -19,7 +19,7 @@ help()
 	completed, it will only take you into the chroot env for building. You will need to 'exit'
 	this env when you are done working in it. It takes the following options.
 
-	-a : Automaticly download and build during unwind.
+	-a : Automatically download and build during unwind.
 	-h : Show this help message.
 	-i : Install the env only. Don't enter it after-wards.
 	-b : Run build after entering chroot and exit after-wards.

--- a/setup-chroot
+++ b/setup-chroot
@@ -38,8 +38,8 @@ get_opts()
 {
 	until [ -z "$1" ] ; do
 		case $1 in
-		-a|--autodl)	export autodl=true;;
-		-i|--install)	install_only=true; export autodl=true;;
+		-a|--autodl)	export AUTODL=true;;
+		-i|--install)	install_only=true; export AUTODL=true;;
 		-b|--build)	export build=true ;;
 		-h|--help)	help ; exit 255 ;;
 		-o|--options)	shift ; export build_opts=$@ ; shift $# ;;

--- a/ts/bin/install_chroot
+++ b/ts/bin/install_chroot
@@ -154,7 +154,7 @@ install_binary_port()
 	Pkgfile=$1
 	if ! install_port $Pkgfile; then
 		port_name=`echo $Pkgfile |cut -d "/" -f6`
-		if ! $autodl; then
+		if ! $AUTODL; then
 			answered=false
 			while ! $answered; do
 				printf "Would you like to try and build it now? Y/N:"
@@ -225,8 +225,8 @@ export -f unwind_package
 export -f install_port
 export -f install_binary_port
 
-if [ -z "$autodl" ]; then
-	autodl=false
+if [ -z "$AUTODL" ]; then
+	AUTODL=false
 fi
 
 ROOT=$PWD

--- a/ts/bin/repackage
+++ b/ts/bin/repackage
@@ -11,7 +11,7 @@ This utility is designed to simplify the folder layout of a crux port into a
 ts package. It will decompress the compiled port archive that belongs to the
 specified package and mangle it for integration into thinstation. By default,
 the destination will be in $TSWRKNG/packages/(specified package) folder.
-This can be overriden with the -t or --temp (path to temp folder)
+This can be overridden with the -t or --temp (path to temp folder)
 syntax.
 
 Usage: repackage (-t (path to temp folder)) (crux port)


### PR DESCRIPTION
The `ts/bin/repackage` script expects `AUTODL` to be defined, but `setup-chroot` was exporting `autodl`, so user was still prompted for downloads.

Updated `install_chroot` to match.