### PR TITLE
fix: bad parsing of ifconfig

### DIFF
--- a/ts/build/packages/base/etc/dialog.functions
+++ b/ts/build/packages/base/etc/dialog.functions
@@ -452,11 +452,11 @@ find_network()
 </window>
 '
 	[ -z $GTKDIALOG ] && GTKDIALOG=gtkdialog
-	if [ -z "`/bin/busybox.shared ifconfig |grep -e 'inet addr' |grep -v 127.0`" ]; then
+	if [ -z "`/bin/busybox.shared ifconfig |grep -e 'inet ' |grep -v 127.0`" ]; then
 		export PACKAGE_NET_WAIT
 		$GTKDIALOG -c --program=BAR_DIALOG
 	fi
-	if [ -z "`/bin/busybox.shared ifconfig |grep -e 'inet addr' |grep -v 127.0`" ]; then
+	if [ -z "`/bin/busybox.shared ifconfig |grep -e 'inet ' |grep -v 127.0`" ]; then
 		x_error "Network" "Timed out waiting for network!"
 		return 1
 	fi


### PR DESCRIPTION
Fix a bug in NETWORK_REQUIRED feature.

# Main bug

The check for network use the following test:
```sh
[ -z "`/bin/busybox.shared ifconfig |grep -e 'inet addr' |grep -v 127.0`" ]
```

The test always fail because it not match the output format of `ifcondig`.

Sample output of ifconfig:

```
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.1.10  netmask 255.255.255.0  broadcast 192.168.1.255
        ether 06:05:04:03:02:01  txqueuelen 1000  (Ethernet)
        RX packets 108947  bytes 26397182 (25.1 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 557  bytes 39126 (38.2 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```

# Proposed fix

Instead of matching `inet addr`, I propose to use `inet ` (with training space for matching only ipv4).