### PR TITLE
Add a new config for enable openssl legacy protocols

### DIFF
--- a/ts/build/conf/openssl.conf.sample
+++ b/ts/build/conf/openssl.conf.sample
@@ -1,0 +1,4 @@
+# Activate legacy provider to support legacy algorithms such as MD4, SHA1, and RC4.
+# This is required for FreeRDP to work with older servers that do not support modern algorithms.
+# For security reasons, it only can be enabled during build time and cannot be enabled at runtime.
+# OPENSSL_LEGACY=true

--- a/ts/build/packages/openssl/build/conf/40openssl
+++ b/ts/build/packages/openssl/build/conf/40openssl
@@ -1,0 +1,4 @@
+# Activate legacy provider to support legacy algorithms such as MD4, SHA1, and RC4.
+# This is required for FreeRDP to work with older servers that do not support modern algorithms.
+# For security reasons, it only can be enabled during build time and cannot be enabled at runtime.
+# OPENSSL_LEGACY=true

--- a/ts/build/packages/openssl/build/finalize
+++ b/ts/build/packages/openssl/build/finalize
@@ -1,0 +1,9 @@
+#OpenSSL_legacy 60
+
+# This script is used to activate legacy algorithms by writing the necessary file.
+if is_enabled "$OPENSSL_LEGACY"; then
+    cat > "/etc/pki/tls/openssl.d/legacy.cnf" <<EOF
+[legacy_set]
+activate = 1
+EOF
+fi


### PR DESCRIPTION
# Add OPENSSL_LEGACY build-time option for legacy algorithm support

## Description
This PR adds a new build-time configuration option `OPENSSL_LEGACY` to enable OpenSSL's legacy provider, addressing compatibility issues with older RDP servers as discussed in #14.

## Changes
- **New configuration file**: `ts/build/packages/openssl/build/conf/40openssl` - Documents the OPENSSL_LEGACY option
- **Finalize script**: `ts/build/packages/openssl/build/finalize` - Dynamically creates `/etc/pki/tls/openssl.d/legacy.cnf` when enabled

## Technical Details
When `OPENSSL_LEGACY=true` is set in `thinstation.conf.buildtime`, the finalize script generates a configuration file that activates OpenSSL's legacy provider. This enables support for deprecated cryptographic algorithms:
- **Hashing**: MD2, MD4, MDC2, WHIRLPOOL, RIPEMD160
- **Ciphers**: Blowfish, CAST, DES, IDEA, RC2, RC4, RC5, SEED
- **KDF**: PBKDF1

## Use Case
Required for FreeRDP connections to older Windows servers that don't support modern cryptographic algorithms. Without this, connections fail with authentication errors.

## Security Considerations
- ⚠️ **Build-time only**: Can only be enabled during image build, not at runtime
- ⚠️ **Weak algorithms**: Enables cryptographically weak algorithms - use only when necessary
- ⚠️ **Well documented**: Includes clear warnings in configuration files

## Testing
- [ ] Verify FreeRDP connections to legacy servers work with `OPENSSL_LEGACY=true`
- [X] Confirm legacy provider is NOT loaded when `OPENSSL_LEGACY=false` or unset
- [X] Check that `/etc/pki/tls/openssl.d/legacy.cnf` is created only when enabled

## Related Issues
Fixes #14
