### PR TITLE
fix lightdm service ExecStart

### DIFF
--- a/ts/build/packages/lightdm/build/extra/etc/systemd/system/lightdm.service.d/overrides.conf
+++ b/ts/build/packages/lightdm/build/extra/etc/systemd/system/lightdm.service.d/overrides.conf
@@ -1,4 +1,4 @@
 [Service]
 EnvironmentFile=/etc/locale.conf
 ExecStart=
-ExecStart=/bin/lightdm
+ExecStart=/bin/env lightdm


### PR DESCRIPTION
## Fix lightdm ExecStart path in systemd service override

### Description
This PR corrects the `ExecStart` directive in the lightdm systemd service override configuration to properly use `/bin/env` for launching lightdm.

On my setup, with last branch on WSL environment, the lightdm binary is located in `/sbin/` istead of `/bin/`. I propose to use the env binary to proper load lightdm.

### Changes
- Modified [`ts/build/packages/lightdm/build/extra/etc/systemd/system/lightdm.service.d/overrides.conf`](ts/build/packages/lightdm/build/extra/etc/systemd/system/lightdm.service.d/overrides.conf:4)
- Changed `ExecStart=/bin/lightdm` to `ExecStart=/bin/env lightdm`

### Rationale
Using `/bin/env` ensures that the lightdm executable is found via the system PATH, making the service more portable.
