### PR TITLE
feat: Add locale files of software if language is enabled on the build

### DIFF
--- a/ts/bin/repackage
+++ b/ts/bin/repackage
@@ -248,7 +248,7 @@ move_run()
 
 extra_dirs()
 {
-	extra_dirs="man pkgconfig aclocal gtk-doc help vala gir-1.0 locale bash-completion cmake omf"
+	extra_dirs="man pkgconfig aclocal gtk-doc help vala gir-1.0 bash-completion cmake omf"
 	if [ "$package" != "python" ] ; then
 		extra_dirs="$extra_dirs include"
 	fi

--- a/ts/build/build
+++ b/ts/build/build
@@ -1825,6 +1825,16 @@ filesystem_fixups()
 		fi
 		depmod -b ./tmp-tree $KERNVER 2>/dev/null
 	fi
+
+	# Clean unnecessary locales
+	installed_locales="`find ./tmp-tree/build -maxdepth 1 -name \*.template`"
+	for localedir in `find ./tmp-tree/usr/share/locale -mindepth 1 -maxdepth 1 -type d`; do
+		ltag=`basename $localedir`
+		if test `find ./tmp-tree/build/ -iname "${ltag}*.template" -type f | wc -l` -eq 0; then
+			rm -rf $localedir
+		fi
+	done
+
 	# Clean up unncessary folders
 	rm -rf ./tmp-tree/{dependencies,build,.dna,.wind,.unwind,configurator.yaml,session_configurator.yaml}
 

--- a/ts/build/packages/xfwm4/build/install
+++ b/ts/build/packages/xfwm4/build/install
@@ -29,7 +29,6 @@ export DROP_DIRS="	lib64/xfce4/backdrops \
 			lib64/xfce4/xfwm4 \
 			lib64/xfce4/dev-tools \
 			lib64/backgrounds \
-			lib64/locale \
 			lib64/themes/Default/balou"
 
 export DROP_FILES="	xfce4-about.desktop \


### PR DESCRIPTION
## PR: Add Locale Files Support for OS Translation (First Step)

### 🌍 Overview
This PR implements the first step towards operating system translation by adding intelligent locale file management during the build process. The system now includes locale files for software packages when specific languages are enabled in the build configuration.

### 📝 Changes Made

#### Modified Files:
- [`ts/build/build`](ts/build/build:1829) - Added locale filtering logic in `filesystem_fixups()`
- [`ts/bin/repackage`](ts/bin/repackage:248) - Removed `locale` from the default exclusion list
- [`ts/build/packages/xfwm4/build/install`](ts/build/packages/xfwm4/build/install:32) - Removed locale directory from DROP_DIRS

### 🔧 Technical Implementation

**New Locale Management Logic:**
The build system now intelligently manages locale files by:

1. **Preserving locale directories** - Removed `locale` from the automatic cleanup list in [`repackage`](ts/bin/repackage:251)

2. **Smart locale filtering** - Added new logic in [`build`](ts/build/build:1829) that:
   - Scans for `.template` files in the build directory to identify enabled languages
   - Iterates through all locale directories in `/usr/share/locale`
   - Keeps only locale directories matching enabled language templates
   - Removes unused locale files to optimize image size

3. **Package-specific adjustments** - Updated xfwm4 package to allow locale files through

### 💡 How It Works

When a language is enabled via a `.template` file (e.g., `fr_FR.template`), the build process:
```bash
# Finds enabled locales from template files
installed_locales="`find ./tmp-tree/build -maxdepth 1 -name \*.template`"

# For each locale directory, checks if matching template exists
for localedir in `find ./tmp-tree/usr/share/locale -mindepth 1 -maxdepth 1 -type d`; do
    ltag=`basename $localedir`
    if test `find ./tmp-tree/build/ -iname "${ltag}*.template" -type f | wc -l` -eq 0; then
        rm -rf $localedir  # Remove if no matching template
    fi
done
```

### ✅ Benefits

- **Reduced image size** - Only includes locale files for enabled languages
- **Translation support** - Enables software packages to display in configured languages
- **Flexible configuration** - Language selection controlled via template files
- **Foundation for full i18n** - First step towards complete OS translation support

### 🎯 Next Steps

This PR establishes the foundation for OS translation. Future work will include:
- Adding language template files for various locales
- Translating system messages and dialogs
- Documentation for language configuration

### 🧪 Testing Recommendations

1. Build with a language template file present
2. Verify only matching locale directories are included in the final image
3. Confirm software displays in the configured language
4. Check image size reduction compared to including all locales

## 🖵 Demo screenshoot

<img width="1312" height="828" alt="image" src="https://github.com/user-attachments/assets/2d8dfc2d-a4e3-4fd4-a312-d6d14b54eb33" />
