### PR TITLE
Fix: Gitignore for NetworkManager

### DIFF
--- a/ts/build/packages/dhclient/.gitignore
+++ b/ts/build/packages/dhclient/.gitignore
@@ -1,3 +1,5 @@
 /etc/
 /sbin/
 /build/installed
+/var/
+/lib64/

--- a/ts/build/packages/networkmanager/.gitignore
+++ b/ts/build/packages/networkmanager/.gitignore
@@ -7,3 +7,6 @@
 /var/
 /build/extra/bin/
 /build/extra/etc/libnl/
+/run/
+/lib64/
+/build/scripts/

--- a/ts/build/packages/wireless/.gitignore
+++ b/ts/build/packages/wireless/.gitignore
@@ -1,3 +1,4 @@
 /lib/
 /sbin/
 /build/installed
+/lib64/

--- a/ts/build/packages/wpa_supplicant/.gitignore
+++ b/ts/build/packages/wpa_supplicant/.gitignore
@@ -2,3 +2,5 @@
 /lib/
 /sbin/
 /build/installed
+/lib64/
+/build/scripts/


### PR DESCRIPTION
Very small PR, for gitignore of networkmanager, dhclient, wireless and wpa_supplicant.