### PR TITLE
Add Evince PDF viewer package

### DIFF
--- a/ts/build/packages/evince/.dna
+++ b/ts/build/packages/evince/.dna
@@ -1,0 +1,4 @@
+,remove,0,0,build,0,,,,,,,,,
+,evince,0,0,build/extra/lib64/menu,0,,,,,,,,,
+,install,0,0,build,0,,,,,,,,,
+,dependencies,0,0,,0,,,,,,,,,

--- a/ts/build/packages/evince/.gitignore
+++ b/ts/build/packages/evince/.gitignore
@@ -1,0 +1,4 @@
+/bin/
+/lib64/
+/libexec/
+/build/installed

--- a/ts/build/packages/evince/build/extra/lib64/menu/evince
+++ b/ts/build/packages/evince/build/extra/lib64/menu/evince
@@ -1,0 +1,1 @@
+package="evince"; needs="x11"; title="PDF Viewer"; command="evince"; nodesktop="true"; menu="Utilities"; icon="org.gnome.Evince"

--- a/ts/build/packages/evince/build/install
+++ b/ts/build/packages/evince/build/install
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+export PACKAGE=evince
+export PORTS="evince evince-libs"
+export DROP_DIRS="lib64/gnome"
+repackage -e
+
+returnval=$?
+
+icon-gen evince
+
+exit $returnval

--- a/ts/build/packages/evince/build/remove
+++ b/ts/build/packages/evince/build/remove
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+export PACKAGE=evince
+repackage -c

--- a/ts/build/packages/evince/dependencies
+++ b/ts/build/packages/evince/dependencies
@@ -1,0 +1,2 @@
+base
+xorg7


### PR DESCRIPTION
This PR adds back in a package for Evince which was lost in the move to the ThinStation 7 series.